### PR TITLE
Issue #74: Changed default in onsite reg to snmc

### DIFF
--- a/MasjidTracker/Models/Visitor.cs
+++ b/MasjidTracker/Models/Visitor.cs
@@ -12,8 +12,8 @@ namespace MasjidTracker.FrontEnd.Models
 {
     public enum Organization
     {
-        Online,
-        SNMC
+        SNMC,
+        Online
     }
     public enum Gender
     {


### PR DESCRIPTION
Changing the 'Signed up via' to SNMC will fix issue #74 .. This "fix" just changes the default to 'SNMC' so that the volunteer doesn't have to worry about it. 